### PR TITLE
chore: update runtime log text to Task Assistant

### DIFF
--- a/src/app/env.ts
+++ b/src/app/env.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 
 /**
- * Environment configuration for the MindForge Orchestrator GitHub App.
+ * Environment configuration for the Task Assistant GitHub App.
  *
  * Responsibilities:
  * - GitHub App authentication (App ID + private key)

--- a/src/app/server.js
+++ b/src/app/server.js
@@ -8,5 +8,5 @@ app.use(express.json({ limit: "2mb" }));
 // Webhook endpoint
 app.post("/github/webhook", githubWebhookRoute);
 app.listen(env.PORT, () => {
-    console.log(`🚀 Orchestrator GitHub App running on port ${env.PORT}`);
+    console.log(`🚀 Task Assistant GitHub App running on port ${env.PORT}`);
 });

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -13,5 +13,5 @@ app.use(express.json({ limit: "2mb" }));
 app.post("/github/webhook", githubWebhookRoute);
 
 app.listen(env.PORT, () => {
-  console.log(`🚀 Orchestrator GitHub App running on port ${env.PORT}`);
+  console.log(`🚀 Task Assistant GitHub App running on port ${env.PORT}`);
 });


### PR DESCRIPTION
This PR updates runtime log and comment text so the GitHub App
identifies itself as Task Assistant.

No behavior, imports, or configuration changes.
Non-breaking and cosmetic only.
